### PR TITLE
Add public company listing

### DIFF
--- a/iwa/app/Http/Controllers/CompanyController.php
+++ b/iwa/app/Http/Controllers/CompanyController.php
@@ -23,6 +23,24 @@ class CompanyController extends Controller
         return view('companies.index', compact('companies', 'selectedCountry', 'countries'));
     }
 
+    /**
+     * Display a public list of all companies.
+     */
+    public function showAll()
+    {
+        $companies = Company::all();
+
+        return view('companies.list', compact('companies'));
+    }
+
+    /**
+     * Return all companies as JSON for the React frontend.
+     */
+    public function apiIndex()
+    {
+        return response()->json(Company::all());
+    }
+
 
     public function create()
     {

--- a/iwa/resources/views/companies/list.blade.php
+++ b/iwa/resources/views/companies/list.blade.php
@@ -1,0 +1,33 @@
+@extends('layouts.app')
+
+@section('content')
+    <div class="container">
+        <h1 class="page-title">All Companies</h1>
+        <table class="user-table">
+            <thead>
+            <tr>
+                <th>Name</th>
+                <th>Street</th>
+                <th>Number</th>
+                <th>Zip code</th>
+                <th>City</th>
+                <th>Country</th>
+                <th>Email</th>
+            </tr>
+            </thead>
+            <tbody>
+            @foreach($companies as $company)
+                <tr>
+                    <td>{{ $company->name }}</td>
+                    <td>{{ $company->street }}</td>
+                    <td>{{ $company->number }}</td>
+                    <td>{{ $company->zip_code }}</td>
+                    <td>{{ $company->city }}</td>
+                    <td>{{ $company->country }}</td>
+                    <td>{{ $company->email }}</td>
+                </tr>
+            @endforeach
+            </tbody>
+        </table>
+    </div>
+@endsection

--- a/iwa/routes/api.php
+++ b/iwa/routes/api.php
@@ -47,6 +47,9 @@ Route::post('/users', [UserController::class, 'store']);
 Route::put('/users/{id}', [UserController::class, 'update']);
 Route::delete('/users/{id}', [UserController::class, 'destroy']);
 
+// Companies for Osaka frontend
+Route::get('/companies', [CompanyController::class, 'apiIndex']);
+
 
 //DEBUG
 Route::get('/user', function (Request $request) {

--- a/iwa/routes/web.php
+++ b/iwa/routes/web.php
@@ -24,6 +24,9 @@ use App\Http\Controllers\ContractAuthController;
 //Homepagina route
 Route::get('/', fn() => view('index'))->name('index');
 
+// Public list of companies
+Route::get('/companies', [CompanyController::class, 'showAll'])->name('companies.list');
+
 //Auth
 Route::get('/login', [AuthController::class, 'showLogin'])->name('login');
 Route::post('/login', [AuthController::class, 'processLogin'])->name('login.process');

--- a/osaka/osaka/src/App.tsx
+++ b/osaka/osaka/src/App.tsx
@@ -3,6 +3,7 @@ import LoginPage from "./pages/LoginPage";
 import AdminPage from "./pages/AdminPage";
 import HomePage from "./pages/HomePage";
 import NearestStationPage from "./pages/NearestStationPage";
+import CompaniesPage from "./pages/CompaniesPage";
 
 function App() {
     return (
@@ -12,6 +13,7 @@ function App() {
                 <Route path="/admin" element={<AdminPage />} />
                 <Route path="/home" element={<HomePage />} />
                 <Route path="/nearest" element={<NearestStationPage />} />
+                <Route path="/companies" element={<CompaniesPage />} />
             </Routes>
         </Router>
     );

--- a/osaka/osaka/src/pages/CompaniesPage.tsx
+++ b/osaka/osaka/src/pages/CompaniesPage.tsx
@@ -1,0 +1,57 @@
+import { useEffect, useState } from "react";
+import axios from "axios";
+
+interface Company {
+    id: number;
+    name: string;
+    street?: string;
+    number?: number;
+    zip_code?: string;
+    city?: string;
+    country?: string;
+    email?: string;
+}
+
+function CompaniesPage() {
+    const [companies, setCompanies] = useState<Company[]>([]);
+
+    useEffect(() => {
+        axios.get<Company[]>("http://127.0.0.1:8000/api/companies").then(res => {
+            setCompanies(res.data);
+        });
+    }, []);
+
+    return (
+        <div>
+            <h1>Companies</h1>
+            <table>
+                <thead>
+                    <tr>
+                        <th>Name</th>
+                        <th>Street</th>
+                        <th>Number</th>
+                        <th>Zip code</th>
+                        <th>City</th>
+                        <th>Country</th>
+                        <th>Email</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {companies.map((c) => (
+                        <tr key={c.id}>
+                            <td>{c.name}</td>
+                            <td>{c.street}</td>
+                            <td>{c.number}</td>
+                            <td>{c.zip_code}</td>
+                            <td>{c.city}</td>
+                            <td>{c.country}</td>
+                            <td>{c.email}</td>
+                        </tr>
+                    ))}
+                </tbody>
+            </table>
+        </div>
+    );
+}
+
+export default CompaniesPage;


### PR DESCRIPTION
## Summary
- add API endpoint to fetch companies as JSON
- implement CompaniesPage in React
- register new route for React page

## Testing
- `vendor/bin/phpunit --filter ExampleTest` *(fails: no such file or directory)*
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845afdd88e48324b3f21f29b7ea12cb